### PR TITLE
Support string keys in `LocaleFlash::Flash.from_params'

### DIFF
--- a/lib/locale_flash/flash.rb
+++ b/lib/locale_flash/flash.rb
@@ -11,11 +11,27 @@ module LocaleFlash
     end
 
     def self.from_params(type, params={})
-      if params.is_a?(Hash) && params[:controller] && params[:action]
+      if params_hash_stringkeys? params
+        build_from_hash_stringkeys type, params
+      elsif params.is_a?(Hash) && params[:controller] && params[:action]
         new(params.merge(:type => type))
       else
         new(:type => type, :message => params.to_s)
       end
+    end
+
+    private_class_method def self.build_from_hash_stringkeys(type, params)
+      new(
+        :type       => type,
+        :controller => params["controller"],
+        :action     => params["action"],
+        :options    => params["options"]
+      )
+    end
+
+    private_class_method def self.params_hash_stringkeys?(params)
+      return false unless params.kind_of? Hash
+      %w[controller action].all? { |key| params.key? key }
     end
 
     def to_params

--- a/spec/locale_flash/flash_spec.rb
+++ b/spec/locale_flash/flash_spec.rb
@@ -72,6 +72,32 @@ describe LocaleFlash::Flash do
         @flash.message.should == "I'm a flash"
       end
     end
+
+    context "when a hash with string keys is passed" do
+      subject :flash do
+        LocaleFlash::Flash.from_params(:notice, {
+          "controller"  => "admin/users",
+          "action"      => "update",
+          "options"     => { "foo" => "bar" }
+        })
+      end
+
+      it "builds the flash" do
+        expect(flash).to be
+      end
+
+      it "sets the controller" do
+        expect(flash.controller).to eq "admin/users"
+      end
+
+      it "sets the action" do
+        expect(flash.action).to eq "update"
+      end
+
+      it "sets the options" do
+        expect(flash.options).to include "foo" => "bar"
+      end
+    end
   end
 
   describe '#to_params' do


### PR DESCRIPTION
  `actionpack` changed how flash messages are stored in version 4.1.0,
indirectly changing the behavior of the `#flash` view helper which now
returns keys as string instead of symbols.
  `LocaleFlash::Rails::ActionView` relies on this view helper, and
passes flash values directly to `LocaleFlash::Flash.from_params`. In
order to support `actionpack ~> 4.1`, we need to support building
`LocaleFlash::Flash` from hash with string keys as well as hash with
symbol keys.

https://github.com/rails/rails/blob/4-1-stable/actionpack/CHANGELOG.md#rails-410-april-8-2014-1

---

https://github.com/rails/rails/commit/a668beffd64106a1e1fedb71cc25eaaa11baf0c1
http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#flash-structure-changes
