### PR TITLE
Fix support for flash with string keys (options)

### DIFF
--- a/lib/locale_flash/flash.rb
+++ b/lib/locale_flash/flash.rb
@@ -25,7 +25,9 @@ module LocaleFlash
         :type       => type,
         :controller => params["controller"],
         :action     => params["action"],
-        :options    => params["options"]
+        :options    => Hash[params["options"].map do |key, value|
+          [key.to_sym, value]
+        end]
       )
     end
 

--- a/spec/locale_flash/flash_spec.rb
+++ b/spec/locale_flash/flash_spec.rb
@@ -78,7 +78,10 @@ describe LocaleFlash::Flash do
         LocaleFlash::Flash.from_params(:notice, {
           "controller"  => "admin/users",
           "action"      => "update",
-          "options"     => { "foo" => "bar" }
+          "options"     => {
+            :foo  => "bar",
+            "baz" => "qux"
+          }
         })
       end
 
@@ -95,7 +98,11 @@ describe LocaleFlash::Flash do
       end
 
       it "sets the options" do
-        expect(flash.options).to include "foo" => "bar"
+        expect(flash.options).to include foo: "bar"
+      end
+
+      it "converts options with a string key to one with a symbol key" do
+        expect(flash.options).to include baz: "qux"
       end
     end
   end


### PR DESCRIPTION
  In 7b47a77 we added support for flash with "string keys", but we
focused on "top level" hash keys. `actionpack` 4.1 also changed behavior
for the *value* of a specific flash entry, the one with the key
"options". Even when we set some options explicitly with a symbol as the
key for a flash message, the helper in the view layer will transform the
symbol to a string.
