### PR TITLE
Support Ruby 3

### DIFF
--- a/lib/locale_flash/flash.rb
+++ b/lib/locale_flash/flash.rb
@@ -76,7 +76,7 @@ module LocaleFlash
       str = if legacy?
         message
       else
-        I18n.t(key, options.merge(:default => fallbacks))
+        I18n.t(key, **options.merge(:default => fallbacks))
       end
       LocaleFlash::Config.template.call(type, str)
     end


### PR DESCRIPTION
fixes `#<ArgumentError: wrong number of arguments (given 2, expected 1)>` on Ruby 3